### PR TITLE
Fix memory leaks in metadata

### DIFF
--- a/metadata/metadata.h
+++ b/metadata/metadata.h
@@ -24,7 +24,7 @@ NVMfTransport *create_nvmf_transport(NVMfTransport__NVMfTransportType type, NVMf
 
 PhysicalDisk *create_physical_disk(Metadata *metadata, NVMfTransport *transport, uint64_t sector_count, uint64_t sector_size, Allocator *allocator);
 
-VirtualDisk *create_virtual_disk(Metadata *metadata, const char *name, uint64_t size, Allocator *allocator);
+VirtualDisk *create_virtual_disk(Metadata *metadata, char *name, uint64_t size, Allocator *allocator);
 
 // map a section of a logical disk to a list of underlying virtual disk ranges
 VirtualDiskRange **translate_vdaddress_to_vdranges(Allocator *allocator, VirtualDisk *vdisk, size_t start_address, size_t io_size);

--- a/samples/metadata-sample.c
+++ b/samples/metadata-sample.c
@@ -79,7 +79,9 @@ int main()
     metadata_persist(database, metadata);
     printf("Wrote MetaData to FDB\n");
 
-    free(metadata);
+    metadata__free_unpacked(metadata, NULL);
+    allocator = NULL;
+    free(allocator);
 
     metadata = metadata_get(database);
 


### PR DESCRIPTION
Valgrind output with current master:
```
==28662== HEAP SUMMARY:
==28662==     in use at exit: 140,622 bytes in 1,041 blocks
==28662==   total heap usage: 9,692 allocs, 8,651 frees, 651,665 bytes allocated
==28662== 
==28662== LEAK SUMMARY:
==28662==    definitely lost: 1,568 bytes in 4 blocks
==28662==    indirectly lost: 15,150 bytes in 364 blocks
==28662==      possibly lost: 0 bytes in 0 blocks
==28662==    still reachable: 123,904 bytes in 673 blocks
==28662==                       of which reachable via heuristic:
==28662==                         stdstring          : 16,081 bytes in 268 blocks
==28662==         suppressed: 0 bytes in 0 blocks
==28662== Rerun with --leak-check=full to see details of leaked memory
==28662== 
==28662== For lists of detected and suppressed errors, rerun with: -s
==28662== ERROR SUMMARY: 36 errors from 2 contexts (suppressed: 0 from 0)
```

with this PR:
```
==28752== HEAP SUMMARY:
==28752==     in use at exit: 127,120 bytes in 782 blocks
==28752==   total heap usage: 10,040 allocs, 9,258 frees, 661,275 bytes allocated
==28752== 
==28752== LEAK SUMMARY:
==28752==    definitely lost: 2,064 bytes in 37 blocks
==28752==    indirectly lost: 1,152 bytes in 72 blocks
==28752==      possibly lost: 0 bytes in 0 blocks
==28752==    still reachable: 123,904 bytes in 673 blocks
==28752==                       of which reachable via heuristic:
==28752==                         stdstring          : 16,081 bytes in 268 blocks
==28752==         suppressed: 0 bytes in 0 blocks
==28752== Rerun with --leak-check=full to see details of leaked memory
==28752== 
==28752== For lists of detected and suppressed errors, rerun with: -s
==28752== ERROR SUMMARY: 36 errors from 2 contexts (suppressed: 0 from 0)
```

so indirectly lost bytes goes down from 15,150 to 1,152 so an improvement overall but still some work to do in upcoming patches