### PR TITLE
Fix final memory leak in metadata

### DIFF
--- a/metadata/metadata.c
+++ b/metadata/metadata.c
@@ -295,8 +295,7 @@ void _add_physical_disk_range_to_virtual_disk_range(VirtualDiskRange *vdr, DiskR
 }
 
 DiskRangeKey* _allocate_next_physical_disk_range(PhysicalDisk *physical_disk, Allocator *allocator) {
-    DiskRangeKey* range = _new_disk_range_key();
-    _memcpy_disk_range_key(range, physical_disk->unallocated_ranges[0]);
+    DiskRangeKey* range = physical_disk->unallocated_ranges[0];
     _add_allocated_physical_disk_range(physical_disk, range);
     for (int i = 0; i < physical_disk->n_unallocated_ranges; i++) {
         physical_disk->unallocated_ranges[i] = physical_disk->unallocated_ranges[i+1];


### PR DESCRIPTION
```
==28852== 
==28852== HEAP SUMMARY:
==28852==     in use at exit: 123,952 bytes in 674 blocks
==28852==   total heap usage: 9,934 allocs, 9,260 frees, 658,101 bytes allocated
==28852== 
==28852== LEAK SUMMARY:
==28852==    definitely lost: 48 bytes in 1 blocks
==28852==    indirectly lost: 0 bytes in 0 blocks
==28852==      possibly lost: 0 bytes in 0 blocks
==28852==    still reachable: 123,904 bytes in 673 blocks
==28852==                       of which reachable via heuristic:
==28852==                         stdstring          : 16,081 bytes in 268 blocks
==28852==         suppressed: 0 bytes in 0 blocks
==28852== Rerun with --leak-check=full to see details of leaked memory
==28852== 
==28852== For lists of detected and suppressed errors, rerun with: -s
==28852== ERROR SUMMARY: 36 errors from 2 contexts (suppressed: 0 from 0)
```